### PR TITLE
fix: double quote array expansions to avoid re-splitting elements

### DIFF
--- a/Wallet/build/deploy.sh
+++ b/Wallet/build/deploy.sh
@@ -138,7 +138,7 @@ if [ "$DeployLinux32" == "1" ]; then
   Files+=("linux32/$Linux32UpdateFile" "linux32/$Linux32SetupFile")
 fi
 cd $DeployPath
-rsync -avR --progress ${Files[@]} "wallet:wallet-updates"
+rsync -avR --progress "${Files[@]}" "wallet:wallet-updates"
 
 echo "Version $AppVersionStrFull was deployed!"
 cd $FullExecPath


### PR DESCRIPTION
In the deployment script, we identified an issue with the array expansion which could lead to unexpected behavior due to re-splitting of its elements.

**Details**:
- **Issue**: We used an unquoted array expansion `${Files[@]}`. If any of its elements contained spaces or other special characters, they would be re-split into separate arguments.
- **Fix**: To prevent this, we've wrapped the array expansion in double quotes: `"${Files[@]}"`. 

This adheres to the recommendation from ShellCheck warning `SC2068`, which advises double-quoting array expansions to prevent globbing and word splitting of individual elements. Not doing so can lead to unexpected behavior, especially when elements of the array contain spaces or special characters.

Reference:
```
Problematic code:
cp $@ ~/dir

Correct code:
cp "$@" ~/dir

Rationale:
Double quotes around $@ (and similarly, ${array[@]}) prevent globbing and word splitting of individual elements, while still expanding to multiple separate arguments.
```

By applying this fix, we ensure the script behaves predictably and correctly, regardless of the content of the array elements.
